### PR TITLE
Make Django-Quintet compatible with Django 1.8

### DIFF
--- a/quintet/models.py
+++ b/quintet/models.py
@@ -6,7 +6,7 @@ from django.db import models
 
 class TimeStampedModel(models.Model):
     created = models.DateTimeField(auto_now_add=True)
-    modified = models.DateTimeField(auto_now_add=True, auto_now=True)
+    modified = models.DateTimeField(auto_now=True)
 
     class Meta:
         abstract = True

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-quintet',
-    version='0.1.2',
+    version='0.1.3',
     packages=['quintet'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Since Django 1.8, the options `auto_now` and `auto_now_add` are mutually
exclusive; combining the two results in an error. Remove `auto_now_add`
from `TimeStampedModel` in order to stay compatible with Django 1.8.
