### PR TITLE
Support for advanced arguments to Django's `EmailMessage`

### DIFF
--- a/quintet/utils.py
+++ b/quintet/utils.py
@@ -5,7 +5,7 @@ from django.conf import settings
 
 
 def send_mail(subject, to_emails, from_email, html_template,
-              text_template=None, data={}, headers={}):
+              text_template=None, data={}, headers={}, **kwargs):
     """Sends an email.
 
     subject       -- subject of the email
@@ -15,14 +15,15 @@ def send_mail(subject, to_emails, from_email, html_template,
     text_template -- plain text template location
     data          -- data needed in the templates
     headers       -- any extra headers
+    kwargs        -- extra arguments passed on to Django's `EmailMessage`
     """
     msg = create_mail(subject, to_emails, from_email, html_template,
-                      text_template, data=data, headers=headers)
+                      text_template, data=data, headers=headers, **kwargs)
     msg.send()
 
 
 def create_mail(subject, to_emails, from_email, html_template,
-                text_template=None, data={}, headers={}):
+                text_template=None, data={}, headers={}, **kwargs):
     """Returns an EmailMultiAlternatives object.
 
     subject       -- subject of the email
@@ -42,7 +43,7 @@ def create_mail(subject, to_emails, from_email, html_template,
         text_content = render_to_string(text_template, data)
 
     msg = EmailMultiAlternatives(subject, text_content, from_email,
-                                 to_emails, headers=headers)
+                                 to_emails, headers=headers, **kwargs)
     msg.attach_alternative(html_content, "text/html")
     msg.return_path = settings.DEFAULT_FROM_EMAIL
     return msg


### PR DESCRIPTION
This adds flexibility in the email utility functions to support passing in more advanced arguments to Django's `EmailMessage` class and sub-classes like `EmailMultiAlternatives`. Advanced arguments are for example the `connection` argument which can be used to provide a persistent SMTP connection when sending many messages at once.
